### PR TITLE
Browser selection option for `gulp serve` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This project comes with several tasks to optimize you development process:
 in `/dist`
 - `gulp serve` - launch a browser sync server on your source files
 - `gulp serve:dist` - lunch a server on your optimized application
+- `gulp serve --browser` - launch a user defined browser sync server on your source files
 - `gulp test` - launch your unit tests with Karma
 - `gulp test:auto` - launch your unit tests with Karma in watch mode
 - `gulp protractor` - launch e2e tests with Protractor

--- a/gulp/server.js
+++ b/gulp/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gulp = require('gulp');
+var gulp = require('gulp-param')(require('gulp'), process.argv);
 
 var paths = gulp.paths;
 
@@ -28,7 +28,7 @@ function browserSyncInit(baseDir, files, browser) {
   });
 }
 
-gulp.task('serve', ['watch'], function () {
+gulp.task('serve', ['watch'], function (browser) {
   browserSyncInit([
     paths.tmp + '/serve',
     paths.src
@@ -39,7 +39,8 @@ gulp.task('serve', ['watch'], function () {
     paths.tmp + '/serve/*.html',
     paths.tmp + '/serve/{app,components}/**/*.html',
     paths.src + '/{app,components}/**/*.html'
-  ]);
+  ],
+  browser);
 });
 
 gulp.task('serve:dist', ['build'], function () {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-uglify": "~1.1.0",
     "gulp-useref": "~1.1.1",
     "gulp-ng-annotate": "~0.5.2",
+    "gulp-param": "^0.6.3",
     "gulp-replace": "~0.5.0",
     "gulp-rename": "~1.2.0",
     "gulp-rev": "~3.0.1",


### PR DESCRIPTION
Add a parameter to 'gulp serve' command named '--browser' where user can specify an installed browser name where to run the server.
